### PR TITLE
Extraction lemma

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ocaml/opam:opensuse-ocaml-5.2
+WORKDIR /home/opam/Failure
+COPY . .
+
+RUN opam init --reinit -ni
+RUN opam update
+RUN opam install dune ppx_deriving odoc ppx_inline_test menhirLib sexplib menhir
+RUN opam exec -- make build
+
+CMD ["bash"]

--- a/lib/analysis/atomic/atomicBase.ml
+++ b/lib/analysis/atomic/atomicBase.ml
@@ -7,7 +7,7 @@ open Ast.HeapRegularCommands
     Each disjunction is handled indipendentely (disj rule)
  *)
 let compute_precondition (command: 'a HeapAtomicCommand.t) (post_condition: NormalForm.t) : NormalForm.t =
-  let precondition = 
+  let precondition =
     match command.node with
     | Skip ->
       post_condition
@@ -37,17 +37,9 @@ let compute_precondition (command: 'a HeapAtomicCommand.t) (post_condition: Norm
       let disjoints = apply_write_v2 mem_id new_name post_condition.disjoints in
       make (fresh_post_condition.variables) disjoints (fresh_post_condition.id_generator)
     | ReadHeap(l_id, r_id) ->
-      let fn1, pc = generate_fresh_existentialized_variable post_condition in
-      let fn2, pc = generate_fresh_existentialized_variable pc in
-      let l = List.map (apply_read pc.variables l_id r_id fn1 fn2 ) pc.disjoints in
-      make (pc.variables) l (pc.id_generator)
-      (* this works but produces lots of "clutter" variables making hard to read the result
-       * In theory they could be removed, but the simplification is not (yet?) smart enough
-       * For now, let's keep the other implementation, that is still correct
-
       let new_name, fresh_post_condition = generate_fresh_existentialized_variable post_condition in
       let new_name2, fresh_post_condition2 = generate_fresh_existentialized_variable fresh_post_condition in
-      let disjoints = apply_read_v2 l_id r_id new_name new_name2 post_condition.disjoints in
-      make (fresh_post_condition2.variables) disjoints (fresh_post_condition2.id_generator) *)
+      let disjoints = apply_read_v2 l_id r_id new_name new_name2 fresh_post_condition2.disjoints in
+      make (fresh_post_condition2.variables) disjoints (fresh_post_condition2.id_generator)
 
   in simplify_formula precondition

--- a/lib/analysis/atomic/heapSemantics.ml
+++ b/lib/analysis/atomic/heapSemantics.ml
@@ -161,8 +161,6 @@ let apply_write_v2 (x : identifier) (new_name: identifier) (disjoints : Formula.
   |> List.map (fun q' -> Formula.AndSeparately(Allocation(x, ArithmeticExpression.Variable new_name), q'))
 
 (* apply the semantics of read using the extract_alloc util *)
-(* TODO: what does new_name2 does? It's used in substituting the expression, but I'm not sure why and if it's enough for it to be a fresh name
-      Maybe this is the cause of the "clutter" variables?  *)
 let apply_read_v2 (l_id : identifier) (r_id : identifier) (new_name: identifier) (new_name2: identifier) (disjoints : Formula.t list) =
   disjoints
   |> List.map (extract_alloc r_id new_name)

--- a/lib/analysis/formulaSimplification/boundVarEqual.ml
+++ b/lib/analysis/formulaSimplification/boundVarEqual.ml
@@ -1,0 +1,52 @@
+open DataStructures
+open DataStructures.Analysis
+open NormalForm
+open Analysis_Utils
+open ExpressionSubstitution
+
+let expr_is_var_or_constant (aexp: ArithmeticExpression.t) : bool =
+  match aexp with
+  | Variable(_) | Literal(_) -> true
+  | _ -> false
+
+let expr_is_var (x : identifier) (aexp : ArithmeticExpression.t) : bool =
+  match aexp with
+  | Variable(y) -> x = y
+  | _ -> false
+
+(* checks if var x is equal to another variable or a constant *)
+let rec is_var_equated (x : identifier) (formula : Formula.t) : ArithmeticExpression.t option =
+  match formula with
+  | True -> Option.None
+  | False -> Option.None
+  | EmptyHeap -> Option.None
+  | NonAllocated(_) -> Option.None
+  | Allocation(_) -> Option.None
+  | And(q1, q2)
+  | AndSeparately(q1, q2) ->
+    let r = is_var_equated x q1 in
+    if Option.is_some r then r else is_var_equated x q2
+  | Comparison(op, lexpr, rexpr) ->
+    if op == BinaryComparison.Equals && expr_is_var x lexpr && not (expr_is_var x rexpr) && expr_is_var_or_constant rexpr then
+      Some(rexpr)
+    else if op == BinaryComparison.Equals && not (expr_is_var x lexpr) && expr_is_var x rexpr && expr_is_var_or_constant lexpr then
+      Some(lexpr)
+    else
+      Option.None
+
+(* for all disjuncts, if var x is equated to some other variable, perform the substitution *)
+let replace_equated_var (x : identifier) (formula: NormalForm.t) : NormalForm.t =
+  (* In theory this never uses the new name because substitutes a variable for a variable. However, I leave it here for safety since it gets removed by subsequent simplification steps *)
+  let new_name, fresh_formula = generate_fresh_existentialized_variable formula in
+  let replace_one_disjunct (disjoint : Formula.t) : Formula.t =
+    match is_var_equated x disjoint with
+    | Some(e) -> substitute_expression_in_formula disjoint e x new_name
+    | None -> disjoint
+  in
+  NormalForm.make (fresh_formula.variables) (List.map replace_one_disjunct fresh_formula.disjoints) (fresh_formula.id_generator)
+
+(** exists a . (a = b) && q = (b = b) && q\[b / a\] and analogously for and-separately *)
+let bound_var_equal (formula: NormalForm.t) : NormalForm.t =
+  IdentifierSet.fold replace_equated_var formula.variables formula
+
+let f = bound_var_equal

--- a/lib/analysis/formulaSimplification/formulaSimplificationBase.ml
+++ b/lib/analysis/formulaSimplification/formulaSimplificationBase.ml
@@ -6,18 +6,16 @@ open Analysis_Utils
 let simplify_formula (formula: NormalForm.t) =
   let simplification_functs = [
     UnitAnd.f;
-    UnitOr.f;
     UnitAndSep.f;
     RemoveDuplicateTrueInAndSep.f;
     NoSharedIdentifierAndSep.f;
-    (* ZeroAnd.f; subsumed by ZeroNormalForm *)
     ExpressionSimplification.f;
     RemoveIdentityComparisons.f;
     DuplicateDisjoints.f;
     BoundVariableCleanup.f;
-    ZeroNormalForm.f;
+    ZeroNormalForm.f
   ] in
-  let rec simplify formula =
+  let rec simplify (formula: NormalForm.t) =
     let simplified = List.fold_left (|>) formula simplification_functs in
     match equal_formulas simplified formula with
     | true  -> simplified

--- a/lib/analysis/formulaSimplification/formulaSimplificationBase.ml
+++ b/lib/analysis/formulaSimplification/formulaSimplificationBase.ml
@@ -9,11 +9,12 @@ let simplify_formula (formula: NormalForm.t) =
     UnitAndSep.f;
     RemoveDuplicateTrueInAndSep.f;
     NoSharedIdentifierAndSep.f;
+    BoundVarEqual.f;
     ExpressionSimplification.f;
     RemoveIdentityComparisons.f;
     DuplicateDisjoints.f;
     BoundVariableCleanup.f;
-    ZeroNormalForm.f
+    ZeroNormalForm.f;
   ] in
   let rec simplify (formula: NormalForm.t) =
     let simplified = List.fold_left (|>) formula simplification_functs in

--- a/lib/analysis/formulaSimplification/formulaSimplificationBase.ml
+++ b/lib/analysis/formulaSimplification/formulaSimplificationBase.ml
@@ -10,11 +10,12 @@ let simplify_formula (formula: NormalForm.t) =
     UnitAndSep.f;
     RemoveDuplicateTrueInAndSep.f;
     NoSharedIdentifierAndSep.f;
-    ZeroAnd.f;
+    (* ZeroAnd.f; subsumed by ZeroNormalForm *)
     ExpressionSimplification.f;
     RemoveIdentityComparisons.f;
     DuplicateDisjoints.f;
     BoundVariableCleanup.f;
+    ZeroNormalForm.f;
   ] in
   let rec simplify formula =
     let simplified = List.fold_left (|>) formula simplification_functs in

--- a/lib/analysis/formulaSimplification/zeroNormalForm.ml
+++ b/lib/analysis/formulaSimplification/zeroNormalForm.ml
@@ -1,0 +1,19 @@
+open DataStructures.Analysis
+open NormalForm
+
+(** p && false = false = p * false, therefore if false appears at any point of a normal form formula, the result is false *)
+let zero_normal_form (formula: NormalForm.t) =
+  let rec contains_false (formula : Formula.t) : bool =
+    match formula with
+    | True -> false
+    | False -> true
+    | And(q1, q2) -> contains_false q1 || contains_false q2
+    | Comparison(_) -> false
+    | EmptyHeap -> false
+    | NonAllocated(_) -> false
+    | Allocation(_) -> false
+    | AndSeparately(q1, q2) -> contains_false q1 || contains_false q2
+  in
+  NormalForm.make formula.variables (List.filter (fun q -> not (contains_false q)) formula.disjoints) formula.id_generator
+
+let f = zero_normal_form

--- a/lib/analysis/formulaSimplification/zeroNormalForm.ml
+++ b/lib/analysis/formulaSimplification/zeroNormalForm.ml
@@ -14,6 +14,8 @@ let zero_normal_form (formula: NormalForm.t) =
     | Allocation(_) -> false
     | AndSeparately(q1, q2) -> contains_false q1 || contains_false q2
   in
-  NormalForm.make formula.variables (List.filter (fun q -> not (contains_false q)) formula.disjoints) formula.id_generator
+  let simplified_disjoints = List.filter (fun q -> not (contains_false q)) formula.disjoints in
+  let simplified_disjoints = if List.length simplified_disjoints = 0 then [Formula.False] else simplified_disjoints in
+  NormalForm.make formula.variables simplified_disjoints formula.id_generator
 
 let f = zero_normal_form


### PR DESCRIPTION
- implemented the extraction lemma (`extract_dealloc` and `extract_alloc` in `lib/analysis/atomic/atomic_Utils.ml`) 
- used it in the rules of spacial atomic commands
- added two simplifications (`ZeroNormalForm` and `BoundVarEqual`) to make the resulting formulae more readable (the extraction lemma introduces lots of extra stuff, most of which gets removed by these two steps)
- fixed a bug in the printing function